### PR TITLE
docs: minor corrections

### DIFF
--- a/RAWDATA/MONGO/simplecontrol.top
+++ b/RAWDATA/MONGO/simplecontrol.top
@@ -1,18 +1,18 @@
 
 
 
-outputmacro: postgres()  # you get harry by default
+outputmacro: mongo()  # you get harry by default
 $cs_token = #DO_INTERJECTION_SPLITTING  | #DO_SUBSTITUTE_SYSTEM   | #DO_NUMBER_MERGE | #DO_DATE_MERGE  | #DO_PROPERNAME_MERGE  | #DO_SPELLCHECK | #DO_PARSE
 ^addtopic(~introductions)
 $cs_control_main = ~control
 $userprompt = ^"%user: >"
-$botprompt = ^"POSTGRES: "
+$botprompt = ^"MONGODB: "
 
 
 table: defaultbot (^name)
 ^createfact(^name defaultbot defaultbot)
 DATA:
-postgres
+mongo
 
 topic: ~control system ()
 

--- a/WIKI/ChatScript-Multiple-Bots.md
+++ b/WIKI/ChatScript-Multiple-Bots.md
@@ -113,6 +113,7 @@ topic: ~topic1 ()
 bot: Ben
 topic: ~topic2 ()   This topic is restricted to Ben
 ...
+```
 
 Furthermore, you don't have to do it per file. You can do it in the filesxxx.txt build file. But you need to
 compile any bot definitions without a bot restriction in effect. E.g.
@@ -144,7 +145,7 @@ topic: ~mytopic SHARE REPEAT ()
 ```
 
 All facts created will be visible to all bots. And if you create a permanent user variable with
-the starting name $share_, then all bots can see and modify it. So $share_name becomes a
+the starting name `$share_`, then all bots can see and modify it. So `$share_name` becomes a
 common variable. When sharing is in effect, the state with the user (what he said, what
 bot said, what turn of the volley this is, where the rejoinder mark is) is all common
 among the bots- they are advancing a joint conversation.
@@ -182,5 +183,3 @@ You disable ownership rules with
 ```
 bot: 0
 ```
-
-

--- a/WIKI/ESOTERIC-CHATSCRIPT/ChatScript-Engine.md
+++ b/WIKI/ESOTERIC-CHATSCRIPT/ChatScript-Engine.md
@@ -340,7 +340,7 @@ finds them in the dictionary, they too are marked.
 
 This ontology marking merges ontology, pos-tagging, parsing, and lemmas (canonical forms) into a single representation suitable for pattern matching. Below is an example.
 
-![](../ontology.png)
+![](../ontolog.png)
 
 ## Script Compiler
 

--- a/WIKI/README.md
+++ b/WIKI/README.md
@@ -141,7 +141,7 @@ really advanced users wanting the appropriate mental model.
  * [ChatScript Foreign Languages](ESOTERIC-CHATSCRIPT/ChatScript-Foreign-Languages.md)
 <br>Running CS in a language other than English.
 
-* [ChatScript Engine](ESOTERIC-CHATSCRIPT/ChatScript-Engine.md)
+ * [ChatScript Engine](ESOTERIC-CHATSCRIPT/ChatScript-Engine.md)
 <br>How the internals of the engine work and how to extend it with private code.
 
 

--- a/WIKI/README.md
+++ b/WIKI/README.md
@@ -94,8 +94,6 @@ really advanced users wanting the appropriate mental model.
 * [Installing and Updating ChatScript](Installing-and-Updating-ChatScript.md)
 <br>Installing on Windows, Mac, Linux. Updating ChatScript (advanced).
 
-* [ChatScript Engine and Private Code Manual](CS-Engine.md)
-<br>How the internals of the engine work and how to extend it with private code.
 
 ## Specialized ChatScript
 
@@ -140,8 +138,11 @@ really advanced users wanting the appropriate mental model.
  * [ChatScript Exotica](ESOTERIC-CHATSCRIPT/ChatScript-Exotica-Examples.md)
 <br>Brief old interesting scripting tips
 
- * [ChatScript Exotica](ESOTERIC-CHATSCRIPT/ChatScript-Foreign-Languages.md)
+ * [ChatScript Foreign Languages](ESOTERIC-CHATSCRIPT/ChatScript-Foreign-Languages.md)
 <br>Running CS in a language other than English.
+
+* [ChatScript Engine](ESOTERIC-CHATSCRIPT/ChatScript-Engine.md)
+<br>How the internals of the engine work and how to extend it with private code.
 
 
 ## Papers in order


### PR DESCRIPTION
Hi Bruce,

* ChatScript-Multiple-Bots.md
  I corrected markdown typo that didn't allow correct visualization

* ChatScript-Engine.md
  I corrected typo on file name ontology 

* README.md
  file links (ChatScript-Engine.md) 

* RASWDATA/MONGO/simplecontrol.top
  minor typo (postgres instead of mongo)

* BTW, thanks! for new MULTI BOT doc / topic update! And blanks bugs fix (just tested) 

regards
giorgio