### PR TITLE
Attempt to fix concept comparison

### DIFF
--- a/SRC/patternSystem.cpp
+++ b/SRC/patternSystem.cpp
@@ -1011,7 +1011,7 @@ DOUBLELEFT:  case '(': case '[':  case '{': // nested condition (required or opt
 					}
 	
 					result = *lhs;
-					if (IsComparison(*op)) // otherwise for words and concepts, look up in sentence and check relation there
+					if (IsComparison(*op) && (result != '~')) // otherwise for words and concepts, look up in sentence and check relation there
 					{
 						if (result == '_' && quoted) --lhs; // include the quote
 						char word1val[MAX_WORD_SIZE];


### PR DESCRIPTION
It seems since version 6.8a the number concept comparison operators may have an issue matching the following:
```
t: How old are you?
    a: (~number<5) You are young.
        b: (~no) You aren't young?
    a: (~number<10) You are a growing child.
    a: (~number<100) You are old.
```
Suggested patch fixes that, but may need to verify if it doesn't break anything else

