### PR TITLE
Be able to specify TMP folder path in command line

### DIFF
--- a/SRC/dictionarySystem.cpp
+++ b/SRC/dictionarySystem.cpp
@@ -1109,7 +1109,7 @@ void ShowStats(bool reset)
 void WriteDictDetailsBeforeLayer(int layer)
 {
 	char word[MAX_WORD_SIZE];
-	sprintf(word,(char*)"TMP/prebuild%d.bin",layer);
+	sprintf(word,(char*)"%s/prebuild%d.bin",tmp, layer);
 	FILE* out = FopenBinaryWrite(word); // binary file, no BOM
 	if (out)
 	{
@@ -1137,7 +1137,7 @@ void WriteDictDetailsBeforeLayer(int layer)
 static void ReadDictDetailsBeforeLayer(int layer)
 {
 	char word[MAX_WORD_SIZE];
-	sprintf(word,(char*)"TMP/prebuild%d.bin",layer);
+	sprintf(word,(char*)"%s/prebuild%d.bin",tmp,layer);
 	int oldBOM = BOM;
 	FILE* in = FopenReadWritten(word); // binary file, no BOM
 	if (in)

--- a/SRC/mainSystem.cpp
+++ b/SRC/mainSystem.cpp
@@ -43,6 +43,7 @@ bool nosuchbotrestart = false; // restart if no such bot
 char users[100];
 char logs[100];
 char topic[100];
+char tmp[100];
 char buildfiles[100];
 char* derivationSentence[MAX_SENTENCE_LENGTH];
 int derivationLength;
@@ -583,6 +584,7 @@ static void ProcessArgument(char* arg)
 	else if (!strnicmp(arg,(char*)"users=",6 )) strcpy(users,arg+6);
 	else if (!strnicmp(arg,(char*)"logs=",5 )) strcpy(logs,arg+5);
 	else if (!strnicmp(arg,(char*)"topic=",6 )) strcpy(topic,arg+6);
+	else if (!strnicmp(arg,(char*)"tmp=",4 )) strcpy(tmp,arg+4);
     else if (!strnicmp(arg, (char*)"buildfiles=", 11)) strcpy(buildfiles, arg + 11);
     else if (!strnicmp(arg,(char*)"private=",8)) privateParams = arg+8;
 	else if (!stricmp(arg,(char*)"treetagger")) strcpy(treetaggerParams,"1");
@@ -684,7 +686,6 @@ static void ReadConfig()
 unsigned int InitSystem(int argcx, char * argvx[],char* unchangedPath, char* readablePath, char* writeablePath, USERFILESYSTEM* userfiles, DEBUGAPI infn, DEBUGAPI outfn)
 { // this work mostly only happens on first startup, not on a restart
 	strcpy(hostname,(char*)"local");
-	MakeDirectory((char*)"TMP");
 	*sourceInput = 0;
     *buildfiles = 0;
 	*apikey = 0;
@@ -714,6 +715,7 @@ unsigned int InitSystem(int argcx, char * argvx[],char* unchangedPath, char* rea
 	strcpy(users,(char*)"USERS");
 	strcpy(logs,(char*)"LOGS");
 	strcpy(topic,(char*)"TOPIC");
+	strcpy(tmp,(char*)"TMP");
 
 	strcpy(language,(char*)"ENGLISH");
 
@@ -756,6 +758,7 @@ unsigned int InitSystem(int argcx, char * argvx[],char* unchangedPath, char* rea
 
 	ReadConfig();
 	ProcessArguments(argc,argv);
+	MakeDirectory(tmp);
 	if (argumentsSeen) printf("\r\n");
 	argumentsSeen = false;
 

--- a/SRC/mainSystem.h
+++ b/SRC/mainSystem.h
@@ -142,6 +142,7 @@ extern bool shortPos;
 extern char users[100];
 extern char logs[100];
 extern char topic[100];
+extern char tmp[100];
 extern char buildfiles[100];
 
 // pending control

--- a/SRC/scriptCompile.cpp
+++ b/SRC/scriptCompile.cpp
@@ -1322,7 +1322,9 @@ static void WriteKey(char* word)
 {
 	if (!compiling || spellCheck != NOTE_KEYWORDS || *word == '_' || *word == '\'' || *word == USERVAR_PREFIX || *word == SYSVAR_PREFIX || *word == '@') return;
 	StoreWord(word);
-	FILE* out = FopenUTF8WriteAppend((char*)"TMP/keys.txt");
+    char file[SMALL_WORD_SIZE];
+    sprintf(file,(char*)"%s/keys.txt",tmp);
+	FILE* out = FopenUTF8WriteAppend(file);
 	if (out)
 	{
 		DownHierarchy(MakeMeaning(StoreWord(word)),out,0);
@@ -5028,15 +5030,18 @@ static void WriteDictionaryChange(FILE* dictout, unsigned int build)
 {
 	// Note that topic labels (topic.name) and pattern words  will not get written
 	FILE* in = NULL;
+    char file[SMALL_WORD_SIZE];
 	int layer = 0;
 	if ( build == BUILD0) 
 	{
-		in = FopenReadWritten((char*)"TMP/prebuild0.bin");
+    sprintf(file,(char*)"%s/prebuild0.bin",tmp);
+		in = FopenReadWritten(file);
 		layer = 0;
 	}
 	else if ( build == BUILD1) 
 	{
-		in = FopenReadWritten((char*)"TMP/prebuild1.bin");
+    sprintf(file,(char*)"%s/prebuild1.bin",tmp);
+		in = FopenReadWritten(file);
 		layer = 1;
 	}
 	if (!in)  

--- a/SRC/userSystem.cpp
+++ b/SRC/userSystem.cpp
@@ -636,11 +636,11 @@ void WriteUserData(time_t curr)
 	if (filesystemOverride == NORMALFILES && (!server || serverRetryOK) && !documentMode && !callback)  
 	{
 		char fname[MAX_WORD_SIZE];
-		sprintf(fname,(char*)"TMP/backup-%s_%s.bin",loginID,computerID);
+		sprintf(fname,(char*)"%s/backup-%s_%s.bin",tmp,loginID,computerID);
 		CopyFile2File(fname, name,false);	// backup for debugging BUT NOT if callback of some kind...
 		if (redo) // multilevel backup enabled
 		{
-			sprintf(fname,(char*)"TMP/backup%d-%s_%s.bin",volleyCount,loginID,computerID);
+			sprintf(fname,(char*)"%s/backup%d-%s_%s.bin",tmp,volleyCount,loginID,computerID);
 			CopyFile2File(fname,userDataBase,false);	// backup for debugging BUT NOT if callback of some kind...
 		}
 	}
@@ -664,11 +664,11 @@ void WriteUserData(time_t curr)
 #ifndef DISCARDTESTING
 		if (filesystemOverride == NORMALFILES &&  (!server || serverRetryOK)  && !documentMode  && !callback)  
 		{
-			sprintf(name,(char*)"TMP/backup-share-%s_%s.bin",loginID,computerID);
+			sprintf(name,(char*)"%s/backup-share-%s_%s.bin",tmp,loginID,computerID);
 			CopyFile2File(name,userDataBase,false);	// backup for debugging
 			if (redo)
 			{
-				sprintf(name,(char*)"TMP/backup%d-share-%s_%s.bin",volleyCount,loginID,computerID);
+				sprintf(name,(char*)"%s/backup%d-share-%s_%s.bin",tmp,volleyCount,loginID,computerID);
 				CopyFile2File(name,userDataBase,false);	// backup for debugging BUT NOT if callback of some kind...
 			}
 		}


### PR DESCRIPTION
The hardcoded TMP directory sometimes can cause problem when you have multiple bots but want to separate them with the engine. And usually you don't have the permission to write to ChatScript home directory if you install ChatScript from package. 

So maybe it's the time to add a command line argument that allows users to specify their tmp directory. 
