### PR TITLE
Only allow .top and .tbl files from RAWDATA

### DIFF
--- a/SRC/scriptCompile.cpp
+++ b/SRC/scriptCompile.cpp
@@ -4827,10 +4827,12 @@ static void ReadTopicFile(char* name,uint64 buildid) //   read contents of a top
 	chunking = false;
 	unsigned int build = (unsigned int) buildid;
 	size_t len = strlen(name);
-	if (len > 1 && name[len-1] == '~') return; // unix backup editor file
-	if (len > 4 && !stricmp(name+len-4,(char*)".bak")) return; // windows backup file
 
-	if (name[len-1] == '~') return; // ignore linux edit backup files
+	// Check the filename is at least four characters (the ext plus one letter)
+	// and matches either .top or .tbl
+	char* suffix = name + len - 4;
+	if (len <= 4) return;
+	if (0 != stricmp(suffix, (char*) ".top") && 0 != stricmp(suffix, (char*) ".tbl")) return;
 
 	FILE* in = FopenReadNormal(name);
 	if (!in) 


### PR DESCRIPTION
As it currently stands, ChatScript will load all files contained in the `RAWDATA` folder (except for the blacklisting of `.bak` and `~` files).

This is fine as long as people strictly stick to actually having .top files inside this folder but, if they don't, ChatScript goes haywire & throws out some syntax warnings, but usually just breaks all conversations.

The situation where I was affected by this problem was including a non-standard filetype inside the directory, which was using a tooling script to transpile certain aspects of if into `.top` files. I wanted to keep both filetypes closely connected and didn't want to make unnecessary new directories. However, these non-standard files were being parsed as if they were top files, which broke CS and made some amusing weird things happen (_"Hat's your name!"_, the bot said)

This issue would, I believe, affect other people too. For example, those who like to put READMEs in multiple folders, or gitignores, etc. So I propose we whitelist top and tbl rather than blacklist OS backup files and the like.

Let me know if this seems acceptable. I worried that there may be some regression if people were using non-top files, but then they probably wouldn't be able to build their bot anyway!

Cheers 😃 
Matt