### PR TITLE
"Too many words in string" should be a warning, not an error

### DIFF
--- a/SRC/scriptCompile.cpp
+++ b/SRC/scriptCompile.cpp
@@ -2389,7 +2389,7 @@ name of topic or concept
 						++n;
 						++ptr;
 					}
-					if (n >= SEQUENCE_LIMIT) BADSCRIPT((char*)"PATTERN-? Too many  words in string %s, will never match\r\n",word)
+					if (n >= SEQUENCE_LIMIT) WARNSCRIPT((char*)"Too many words in string %s, may never match\r\n",word)
 				}
 				break;
 			case SYSVAR_PREFIX: //   system data


### PR DESCRIPTION
By being a warning and saying "will never match", it appears as if ChatScript will fail to match the given pattern, but this is not true. In our instance, we know exactly what is being sent in, and it should match exactly as given.

Therefore, this should be a warning for bot quality guidance and not an error that completely blocks the build.