### PR TITLE
Remove runtime dependency for dictionarySystem.h

### DIFF
--- a/DICT/dictionary_system.txt
+++ b/DICT/dictionary_system.txt
@@ -1,21 +1,14 @@
-#ifndef _DICTIONARYSYSTEM_H
-#define _DICTIONARYSYSTEM_H
+// Copyright (C)2011-2018 by Bruce Wilcox
 
-#ifdef INFORMATION
-Copyright (C)2011-2018 by Bruce Wilcox
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#endif
-
-typedef unsigned int DICTINDEX; // indexed ref to a dictionary entry
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // This file has formatting restrictions because it is machine read by AcquireDefines. All macro and function calls
 // must keep their ( attached to the name and all number defines must not.
@@ -681,10 +674,3 @@ typedef unsigned int DICTINDEX; // indexed ref to a dictionary entry
 #define ALL_RESPONSES ( RESPONSE_UPPERSTART | RESPONSE_REMOVESPACEBEFORECOMMA | RESPONSE_ALTERUNDERSCORES | RESPONSE_REMOVETILDE | RESPONSE_NOCONVERTSPECIAL )
 
 #define ASSIGNMENT 0x01000000 //used by performassignment
-
-
-typedef void (*DICTIONARY_FUNCTION)(WORDP D, uint64 data);
-
-#include "dictionaryMore.h"
-
-#endif

--- a/SRC/dictionarySystem.cpp
+++ b/SRC/dictionarySystem.cpp
@@ -3377,7 +3377,7 @@ void LoadDictionary()
 	if (!ReadBinaryDictionary()) //   if binary form not there or wrong hash, use text form (slower)
 	{
 		InitFactWords(); 
-		AcquireDefines((char*)"SRC/dictionarySystem.h"); //   get dictionary defines (must occur before loop that decodes properties into sets (below)
+		AcquireDefines((char*)"DICT/dictionary_system.txt"); //   get dictionary defines (must occur before loop that decodes properties into sets (below)
 		if (ReadAsciiDictionary())
 		{
 			*currentFilename = 0;
@@ -3391,7 +3391,7 @@ void LoadDictionary()
 	{
 		WORDP hold = dictionaryFree;
 		InitFactWords(); 
-		AcquireDefines((char*)"SRC/dictionarySystem.h"); 
+		AcquireDefines((char*)"DICT/dictionary_system.txt"); 
 		if (dictionaryFree != hold) ReportBug((char*)"FATAL: dict changed after binary read+supplement\r\n")
 	}
 	ReadAbbreviations((char*)"abbreviations.txt"); // needed for burst/tokenizing
@@ -7432,7 +7432,7 @@ void LoadRawDictionary(int mini) // 6 == foreign
 	fclose(out);
 	ClearWordMaps();
 
-	AcquireDefines("src/dictionarySystem.h"); // need to process raw dictionary data but should NOT be final dict, since this is a dynamic file
+	AcquireDefines("DICT/dictionary_system.txt"); // need to process raw dictionary data but should NOT be final dict, since this is a dynamic file
 	InitFactWords();
 	ExtendDictionary();
 	Dqword = StoreWord("~qwords");

--- a/SRC/mainSystem.cpp
+++ b/SRC/mainSystem.cpp
@@ -801,7 +801,7 @@ unsigned int InitSystem(int argcx, char * argvx[],char* unchangedPath, char* rea
 	*traceuser = 0;
 	*hide = 0;
 	*botheader = 0;
-	FILE* in = FopenStaticReadOnly((char*)"SRC/dictionarySystem.h"); // SRC/dictionarySystem.h
+	FILE* in = FopenStaticReadOnly((char*)"DICT/dictionary_system.txt");
 	if (!in) // if we are not at top level, try going up a level
 	{
 #ifdef WIN32

--- a/SRC/testing.cpp
+++ b/SRC/testing.cpp
@@ -9143,7 +9143,7 @@ static void BuildForeign(char* input)
 	InitCache();
 
 	InitFactWords();
-	AcquireDefines((char*)"SRC/dictionarySystem.h"); //   get dictionary defines (must occur before loop that decodes properties into sets (below)
+	AcquireDefines((char*)"DICT/dictionary_system.txt"); //   get dictionary defines (must occur before loop that decodes properties into sets (below)
 
 	char name[MAX_WORD_SIZE];
 	sprintf(name, "DICT/%s", language);

--- a/SRC/textUtilities.cpp
+++ b/SRC/textUtilities.cpp
@@ -659,10 +659,10 @@ double Convert2Float(char* original, int useNumberStyle)
 
 void AcquireDefines(char* fileName)
 { // dictionary entries:  `xxxx (property names)  ``xxxx  (systemflag names)  ``` (parse flags values)  -- and flipped:  `nxxxx and ``nnxxxx and ```nnnxxx with infermrak being ptr to original name
-	FILE* in = FopenStaticReadOnly(fileName); // SRC/dictionarySystem.h
+	FILE* in = FopenStaticReadOnly(fileName); // DICT/dictionary_system.txt
 	if (!in) 
 	{
-		if ( !server) (*printer)((char*)"%s", (char*)"Unable to read dictionarySystem.h\r\n");
+		if ( !server) (*printer)((char*)"%s", (char*)"Unable to read DICT/dictionary_system.txt\r\n");
 		return;
 	}
 	char label[MAX_WORD_SIZE];


### PR DESCRIPTION
Resolves #227 

This commit means that there will be the `#DEFINE` rows both in `SRC/dictionarySystem.h` and `DICT/dictionary_system.txt`, but it also means that the binaries are not loading in `.h` files at run-time, and allows users to create a super slimline workable version of ChatScript using only `BINARIES`, `DICT`, `LIVEDATA`, and `RAWDATA`